### PR TITLE
[jspm] Fix 'es6-module-loader.js does not match any file' when running tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -41,7 +41,8 @@ module.exports = function(config) {
     },
 
     proxies: {
-      // '/jspm_packages': '/base/jspm_packages',
+      '/client': '/base/client',
+      '/jspm_packages': '/base/client/jspm_packages',
       // '/jspm.config.js': '/base/jspm.config.js'
     },
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "karma": "^0.12.36",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.1.12",
-    "karma-jspm": "^1.1.5",
+    "karma-jspm": "^2.0.2",
     "karma-mocha": "^0.1.10",
     "karma-mocha-reporter": "^1.0.2",
     "rimraf": "^2.4.3",


### PR DESCRIPTION
Running tests on a fresh clone in the jspm branch, I was getting the following error:
```bash
Pattern ".../client/jspm_packages/es6-module-loader.js" does not match any file.
```
Fixed in 2.0.1 according to Workiva/karma-jspm#88

After updating karma-jspm, karma gave this error:
```bash
ERROR: 'Potentially unhandled rejection [4] Error: XHR error (404 Not Found) loading http://localhost:9876/client/app/common/hero/hero.spec.js
```
This required the changes to the proxies section to load all js properly.
