### PR TITLE
Improve build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 node_modules
 .settings
 *.log
-client/bundle.js
-client/bundle.js.map
+dist/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ NG6 uses Gulp and Webpack together for its build system. Yes, you don't need Gul
 * Transpiling from ES6 to ES5 with `Babel`
 * Loading HTML files as modules
 * Transpiling stylesheets and appending them to the DOM
+* Refreshing the browser and rebuilding on file changes
+* Hot module replacement for transpiled stylesheets
 * Bundling the app
 * Loading all modules
 * Doing all of the above for `*.spec.js` files as well
@@ -51,7 +53,6 @@ NG6 uses Gulp and Webpack together for its build system. Yes, you don't need Gul
 `Gulp` is the orchestrator:
 * Starting and calling Webpack
 * Starting a development server (yes, Webpack can do this too)
-* Refreshing the browser and rebuilding on file changes
 * Generating boilerplate for the Angular app
 
 **Check out the [JSPM version](https://github.com/angularclass/NG6-starter/tree/jspm)--an alternative to Webpack as an ES6 build system.**
@@ -103,13 +104,13 @@ NG6 uses Gulp to build and launch the development environment. After you have in
 ### Gulp Tasks
 Here's a list of available tasks:
 * `webpack`
-  * runs Webpack, which will transpile, concatenate, and compress (collectively, "bundle") all assets and modules into `client/bundle.js`.
+  * runs Webpack, which will transpile, concatenate, and compress (collectively, "bundle") all assets and modules into `dist/bundle.js`. It also prepares `index.html` to be used as application entry point, links assets and created dist version of our application.
 * `serve`
-  * starts a dev server via `browser-sync`, serving the client folder.
+  * starts a dev server via `webpac-dev-server`, serving the client folder.
 * `watch`
-  * listens for file changes, rebuilds with Webpack, then refreshes the browser.
+  * alias of `serve`
 * `default` (which is the default task that runs when typing `gulp` without providing an argument)
-	* runs `webpack`, `serve`, and `watch`--in that order.
+	* runs `serve`.
 * `component`
   * scaffolds a new Angular component. [Read below](#generating-components) for usage details.
   

--- a/client/index.html
+++ b/client/index.html
@@ -9,6 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="description" content="NG6-Starter by @AngularClass">
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/webpack-dev-server.js"></script>
     <base href="/">
   </head>
   <body ng-app="app" ng-strict-di ng-cloak>
@@ -18,7 +19,7 @@
     </app>
 
     <script src="bundle.js"></script>
-    
+
     <!-- Google Analytics: change UA-71073175-2 to be your site's ID -->
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/client/index.html
+++ b/client/index.html
@@ -9,16 +9,12 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="description" content="NG6-Starter by @AngularClass">
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-    <script src="/webpack-dev-server.js"></script>
-    <base href="/">
   </head>
   <body ng-app="app" ng-strict-di ng-cloak>
 
     <app>
       Loading...
     </app>
-
-    <script src="bundle.js"></script>
 
     <!-- Google Analytics: change UA-71073175-2 to be your site's ID -->
     <script>

--- a/client/index.html
+++ b/client/index.html
@@ -9,6 +9,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
     <meta name="description" content="NG6-Starter by @AngularClass">
     <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <base href="/">
   </head>
   <body ng-app="app" ng-strict-di ng-cloak>
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import gulp     from 'gulp';
-import webpack  from 'webpack-stream';
+import webpack  from 'webpack';
 import path     from 'path';
 import sync     from 'run-sequence';
 import serve    from 'browser-sync';
@@ -10,6 +10,9 @@ import template from 'gulp-template';
 import fs       from 'fs';
 import yargs    from 'yargs';
 import lodash   from 'lodash';
+import gutil    from 'gulp-util';
+
+import colorsSupported from 'supports-color';
 
 let reload = () => serve.reload();
 let root = 'client';
@@ -31,16 +34,29 @@ let paths = {
     resolveToApp('**/*.html'),
     path.join(root, 'index.html')
   ],
-  entry: path.join(root, 'app/app.js'),
+  entry: './' + path.join(root, 'app/app.js'),
   output: root,
   blankTemplates: path.join(__dirname, 'generator', 'component/**/*.**')
 };
 
 // use webpack.config.js to build modules
-gulp.task('webpack', () => {
-  return gulp.src(paths.entry)
-    .pipe(webpack(require('./webpack.config')))
-    .pipe(gulp.dest(paths.output));
+gulp.task('webpack', (cb) => {
+  const config = require('./webpack.config');
+  config.entry.app = paths.entry;
+
+  webpack(config, (err, stats) => {
+    if(err)  {
+      throw new gutil.PluginError("webpack", err);
+    }
+
+    gutil.log("[webpack]", stats.toString({
+      colors: colorsSupported,
+      chunks: false,
+      errorDetails: true
+    }));
+
+    cb();
+  });
 });
 
 gulp.task('serve', () => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -2,6 +2,7 @@
 
 import gulp     from 'gulp';
 import webpack  from 'webpack';
+import WebpacDevServer from 'webpack-dev-server';
 import path     from 'path';
 import sync     from 'run-sequence';
 import serve    from 'browser-sync';
@@ -60,11 +61,30 @@ gulp.task('webpack', (cb) => {
 });
 
 gulp.task('serve', () => {
-  serve({
-    port: process.env.PORT || 3000,
-    open: false,
-    server: { baseDir: root }
+  const config = require('./webpack.config');
+  config.entry.app = ['webpack/hot/dev-server', paths.entry];
+
+  var server = new WebpacDevServer(webpack(config), {
+    stats: {
+      colors: true,
+      chunks: false,
+      modules: false
+    },
+    hot: true,
+    lazy: false,
+    contentBase: paths.output
   });
+  server.listen(
+    process.env.PORT || 3000,
+    process.env.HOST || 'localhost',
+    function(err) {
+      if(err) {
+        throw new gutil.PluginError("webpack-dev-server", err);
+      }
+
+      gutil.log("[webpack-dev-server]", "http://localhost:8080/webpack-dev-server/index.html");
+    }
+  );
 });
 
 gulp.task('watch', () => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,7 +5,6 @@ import webpack  from 'webpack';
 import WebpacDevServer from 'webpack-dev-server';
 import path     from 'path';
 import sync     from 'run-sequence';
-import serve    from 'browser-sync';
 import rename   from 'gulp-rename';
 import template from 'gulp-template';
 import fs       from 'fs';
@@ -15,7 +14,6 @@ import gutil    from 'gulp-util';
 
 import colorsSupported from 'supports-color';
 
-let reload = () => serve.reload();
 let root = 'client';
 
 // helper method for resolving paths
@@ -87,10 +85,7 @@ gulp.task('serve', () => {
   );
 });
 
-gulp.task('watch', () => {
-  let allPaths = [paths.js, ...paths.html, paths.styl];
-  gulp.watch(allPaths, ['webpack', reload]);
-});
+gulp.task('watch', ['serve']);
 
 gulp.task('component', () => {
   const cap = (val) => {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -33,7 +33,7 @@ let paths = {
     resolveToApp('**/*.html'),
     path.join(root, 'index.html')
   ],
-  entry: './' + path.join(root, 'app/app.js'),
+  entry: path.join(__dirname, root, 'app/app.js'),
   output: root,
   blankTemplates: path.join(__dirname, 'generator', 'component/**/*.**')
 };
@@ -64,8 +64,11 @@ gulp.task('serve', () => {
 
   const config = require('./webpack.dev.config');
   config.entry.app = [
+    // this modules required to make HRM working
+    // it responsible for all this webpack magic
     `webpack-dev-server/client?http://${HOST}:${PORT}`,
     'webpack/hot/dev-server',
+    // application entry point
     paths.entry
   ];
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -40,7 +40,7 @@ let paths = {
 
 // use webpack.config.js to build modules
 gulp.task('webpack', (cb) => {
-  const config = require('./webpack.config');
+  const config = require('./webpack.dist.config');
   config.entry.app = paths.entry;
 
   webpack(config, (err, stats) => {
@@ -59,8 +59,15 @@ gulp.task('webpack', (cb) => {
 });
 
 gulp.task('serve', () => {
-  const config = require('./webpack.config');
-  config.entry.app = ['webpack/hot/dev-server', paths.entry];
+  const PORT = process.env.PORT || 3000;
+  const HOST = process.env.HOST || 'localhost';
+
+  const config = require('./webpack.dev.config');
+  config.entry.app = [
+    `webpack-dev-server/client?http://${HOST}:${PORT}`,
+    'webpack/hot/dev-server',
+    paths.entry
+  ];
 
   var server = new WebpacDevServer(webpack(config), {
     stats: {
@@ -73,14 +80,14 @@ gulp.task('serve', () => {
     contentBase: paths.output
   });
   server.listen(
-    process.env.PORT || 3000,
-    process.env.HOST || 'localhost',
+    PORT,
+    HOST,
     function(err) {
       if(err) {
         throw new gutil.PluginError("webpack-dev-server", err);
       }
 
-      gutil.log("[webpack-dev-server]", "http://localhost:8080/webpack-dev-server/index.html");
+      gutil.log("[webpack-dev-server]", "http://localhost:3000/webpack-dev-server/index.html");
     }
   );
 });
@@ -106,6 +113,4 @@ gulp.task('component', () => {
     .pipe(gulp.dest(destPath));
 });
 
-gulp.task('default', (done) => {
-  sync('webpack', 'serve', 'watch', done);
-});
+gulp.task('default', ['serve']);

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -15,13 +15,11 @@ let reload = () => serve.reload();
 let root = 'client';
 
 // helper method for resolving paths
-let resolveToApp = (glob) => {
-  glob = glob || '';
+let resolveToApp = (glob = '') => {
   return path.join(root, 'app', glob); // app/{glob}
 };
 
-let resolveToComponents = (glob) => {
-  glob = glob || '';
+let resolveToComponents = (glob = '') => {
   return path.join(root, 'app/components', glob); // app/components/{glob}
 };
 
@@ -54,17 +52,17 @@ gulp.task('serve', () => {
 });
 
 gulp.task('watch', () => {
-  let allPaths = [].concat([paths.js], paths.html, [paths.styl]);
+  let allPaths = [paths.js, ...paths.html, paths.styl];
   gulp.watch(allPaths, ['webpack', reload]);
 });
 
 gulp.task('component', () => {
-  let cap = (val) => {
+  const cap = (val) => {
     return val.charAt(0).toUpperCase() + val.slice(1);
   };
-  let name = yargs.argv.name;
-  let parentPath = yargs.argv.parent || '';
-  let destPath = path.join(resolveToComponents(), parentPath, name);
+  const name = yargs.argv.name;
+  const parentPath = yargs.argv.parent || '';
+  const destPath = path.join(resolveToComponents(), parentPath, name);
 
   return gulp.src(paths.blankTemplates)
     .pipe(template({

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "angular-mocks": "^1.3.15",
     "babel-core": "^5.4.2",
     "babel-loader": "^5.0.0",
-    "browser-sync": "^2.7.1",
     "chai": "^3.4.0",
     "css-loader": "^0.19.0",
     "fs-walk": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "stylus-loader": "^1.1.1",
     "supports-color": "^3.1.2",
     "webpack": "^1.9.5",
+    "webpack-dev-server": "^1.14.1",
     "yargs": "^3.9.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-template": "^3.0.0",
     "gulp-util": "^3.0.7",
+    "html-webpack-plugin": "^1.7.0",
     "karma": "^0.13.9",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "angular-mocks": "^1.3.15",
     "babel-core": "^5.4.2",
     "babel-loader": "^5.0.0",
+    "browser-sync": "^2.11.1",
     "chai": "^3.4.0",
     "css-loader": "^0.19.0",
     "fs-walk": "0.0.1",
@@ -38,7 +39,8 @@
     "stylus-loader": "^1.1.1",
     "supports-color": "^3.1.2",
     "webpack": "^1.9.5",
-    "webpack-dev-server": "^1.14.1",
+    "webpack-dev-middleware": "^1.4.0",
+    "webpack-hot-middleware": "^2.6.0",
     "yargs": "^3.9.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp": "^3.9.0",
     "gulp-rename": "^1.2.2",
     "gulp-template": "^3.0.0",
+    "gulp-util": "^3.0.7",
     "karma": "^0.13.9",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.0",
@@ -35,8 +36,8 @@
     "run-sequence": "^1.1.0",
     "style-loader": "^0.12.2",
     "stylus-loader": "^1.1.1",
+    "supports-color": "^3.1.2",
     "webpack": "^1.9.5",
-    "webpack-stream": "^2.0.0",
     "yargs": "^3.9.0"
   },
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,14 +14,17 @@ module.exports = {
     ]
   },
   plugins: [
+    // Injects bundles in your index.html instead of wiring all manually.
+    // It also adds hash to all injected assets so we don't have problems
+    // with cache purging during deployment.
     new HtmlWebpackPlugin({
       template: 'client/index.html',
       inject: 'body',
       hash: true
     }),
 
-    // Automatically move all modules defined outside of application directory to vendor bundle
-    // If you are using more complicated project structure, consider to specify common chunks manually
+    // Automatically move all modules defined outside of application directory to vendor bundle.
+    // If you are using more complicated project structure, consider to specify common chunks manually.
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       minChunks: function (module, count) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,13 @@
+var path    = require('path');
+var webpack = require('webpack');
 
 module.exports = {
   devtool: 'sourcemap',
+  entry: {
+  },
   output: {
-    filename: 'bundle.js'
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'client')
   },
   module: {
     loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,15 @@ module.exports = {
       template: 'client/index.html',
       inject: 'body',
       hash: true
+    }),
+
+    // Automatically move all modules defined outside of application directory to vendor bundle
+    // If you are using more complicated project structure, consider to specify common chunks manually
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: function (module, count) {
+        return module.resource && module.resource.indexOf(path.resolve(__dirname, 'client')) === -1;
+      }
     })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   output: {
     filename: 'bundle.js',
+    publicPath: '/',
     path: path.resolve(__dirname, 'client')
   },
   module: {
@@ -16,5 +17,8 @@ module.exports = {
        { test: /\.styl$/, loader: 'style!css!stylus' },
        { test: /\.css$/, loader: 'style!css' }
     ]
-  }
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin()
+  ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,15 +1,10 @@
 var path    = require('path');
 var webpack = require('webpack');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
   devtool: 'sourcemap',
-  entry: {
-  },
-  output: {
-    filename: 'bundle.js',
-    publicPath: '/',
-    path: path.resolve(__dirname, 'client')
-  },
+  entry: {},
   module: {
     loaders: [
        { test: /\.js$/, exclude: [/app\/lib/, /node_modules/], loader: 'ng-annotate!babel' },
@@ -19,6 +14,10 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.HotModuleReplacementPlugin()
+    new HtmlWebpackPlugin({
+      template: 'client/index.html',
+      inject: 'body',
+      hash: true
+    })
   ]
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,16 +1,19 @@
 var webpack = require('webpack');
 var path    = require('path');
 var config  = require('./webpack.config');
-var lodash  = require('lodash');
-
-config.plugins = config.plugins.concat([
-  new webpack.HotModuleReplacementPlugin()
-]);
 
 config.output = {
   filename: '[name].bundle.js',
-    publicPath: '/',
-    path: path.resolve(__dirname, 'client')
+  publicPath: '/',
+  path: path.resolve(__dirname, 'client')
 };
+
+config.plugins = config.plugins.concat([
+
+  // Adds webpack HMR support. It act's like livereload,
+  // reloading page after webpack rebuilt modules.
+  // It also updates stylesheets and inline assets without page reloading.
+  new webpack.HotModuleReplacementPlugin()
+]);
 
 module.exports = config;

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -8,7 +8,7 @@ config.plugins = config.plugins.concat([
 ]);
 
 config.output = {
-  filename: 'bundle.js',
+  filename: '[name].bundle.js',
     publicPath: '/',
     path: path.resolve(__dirname, 'client')
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,16 @@
+var webpack = require('webpack');
+var path    = require('path');
+var config  = require('./webpack.config');
+var lodash  = require('lodash');
+
+config.plugins = config.plugins.concat([
+  new webpack.HotModuleReplacementPlugin()
+]);
+
+config.output = {
+  filename: 'bundle.js',
+    publicPath: '/',
+    path: path.resolve(__dirname, 'client')
+};
+
+module.exports = config;

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -1,6 +1,6 @@
 var webpack = require('webpack');
-var path = require('path');
-var config = require('./webpack.config');
+var path    = require('path');
+var config  = require('./webpack.config');
 
 config.output = {
   filename: '[name].bundle.js',
@@ -9,9 +9,16 @@ config.output = {
 };
 
 config.plugins = config.plugins.concat([
+
+  // Reduces bundles total size
   new webpack.optimize.UglifyJsPlugin({
     mangle: {
-      except: ['$super', '$', 'window', 'exports', 'require', 'moment', 'angular']
+
+      // You can specify all variables that should not be mangled.
+      // For example if your vendor dependency doesn't use modules
+      // and relies on global variables. Most of angular modules relies on
+      // angular global variable, so we should keep it unchanged
+      except: ['$super', '$', 'exports', 'require', 'angular']
     }
   })
 ]);

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -3,7 +3,7 @@ var path = require('path');
 var config = require('./webpack.config');
 
 config.output = {
-  filename: 'bundle.js',
+  filename: '[name].bundle.js',
   publicPath: '',
   path: path.resolve(__dirname, 'dist')
 };

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -1,0 +1,19 @@
+var webpack = require('webpack');
+var path = require('path');
+var config = require('./webpack.config');
+
+config.output = {
+  filename: 'bundle.js',
+  publicPath: '',
+  path: path.resolve(__dirname, 'dist')
+};
+
+config.plugins = config.plugins.concat([
+  new webpack.optimize.UglifyJsPlugin({
+    mangle: {
+      except: ['$super', '$', 'window', 'exports', 'require', 'moment', 'angular']
+    }
+  })
+]);
+
+module.exports = config;


### PR DESCRIPTION
- [x] Switch from `webpack-stream` to just webpack node.js API.
- [x] Switch from `browser-sync` to `webpack-dev-server` for incremental builds
- [x] Add HMR for CSS
- [x] Add separate config for dist and dev builds with uglify js (covers #39 and helps with #33)
- [x] Inject assets into `index.html` automatically (I'm to lazy to do this on my own hands)
- [x] Add some notes into readme.
- [x] Add vendor libs to separate chunk
- [x] Add comments to `webpack.*.config` files in order to illustrate purposes of different settings.

This PR needs code review. Also will be glad to get some other suggestions.
