### PR TITLE
chore(readme): Use 0.0.6 component() polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "angular": "^1.4.4",
-    "angular-component": "0.0.3",
+    "angular-component": "0.0.6",
     "angular-ui-router": "^0.2.15",
     "lodash": "^3.8.0",
     "normalize.css": "^3.0.3"


### PR DESCRIPTION
This change fixes a bug that was present in Angular 1.5 (template Array dependency annotation). Also aligns with latest Object merge changes for `$` prefixed props.