### PR TITLE
Update angular to 1.5.0

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import uiRouter from 'angular-ui-router';
-import angularComponent from 'angular-component';
 import Common from './common/common';
 import Components from './components/components';
 import AppComponent from './app.component';

--- a/package.json
+++ b/package.json
@@ -4,14 +4,13 @@
   "description": "Starter for Angular + ES6 + (Webpack or JSPM)",
   "main": "index.js",
   "dependencies": {
-    "angular": "^1.4.4",
-    "angular-component": "0.0.6",
+    "angular": "^1.5.0",
     "angular-ui-router": "^0.2.15",
     "lodash": "^3.8.0",
     "normalize.css": "^3.0.3"
   },
   "devDependencies": {
-    "angular-mocks": "^1.3.15",
+    "angular-mocks": "^1.5.0",
     "babel-core": "^5.4.2",
     "babel-loader": "^5.0.0",
     "browser-sync": "^2.11.1",

--- a/spec.bundle.js
+++ b/spec.bundle.js
@@ -9,8 +9,6 @@
 */
 
 import angular from 'angular';
-// Import `.component` helper backport
-import 'angular-component';
 
 // Built by the core Angular team for mocking dependencies
 import mocks from 'angular-mocks';


### PR DESCRIPTION
Since Angular 1.5 released, I think it is useful to make this starter relay on latest stable version.

Also this allows to drop dependency from `angular-component`.