### PR TITLE
Fix a typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Following a consistent directory structure between components offers us the cert
 ⋅⋅⋅⋅⋅⋅⋅⋅componentName.spec.js // contains passing demonstration tests
 ```
 
-You may, of course, create these files manually, every time a new module is needed, but that gets quickly tedius.
+You may, of course, create these files manually, every time a new module is needed, but that gets quickly tedious.
 To generate a component, run `gulp component --name componentName`.
 
 The parameter following the `--name` flag is the name of the component to be created. Ensure that it is unique or it will overwrite the preexisting identically-named component.


### PR DESCRIPTION
`tedius` → `tedious`