### PR TITLE
Add e2e tests

### DIFF
--- a/client/app/components/about/about.e2e.js
+++ b/client/app/components/about/about.e2e.js
@@ -1,0 +1,33 @@
+describe('About Route', () => {
+
+	// Before each test
+	beforeEach(() => {
+
+		// Navigate to about component
+    browser.get('http://localhost:3000/about');
+  });
+
+	// About component should be visible
+  it('should be visible', () => {
+
+    // Expect home component to be visible
+    expect(element(by.tagName('about')).isDisplayed()).toBe(true);
+  });
+
+  // Link to Home navigates to Home Component
+  it('should navigate to Home if Home link clicked', () => {
+
+    // Click navigation to Home route
+    element(by.css('[ui-sref="home"]'))
+      .click()
+      .then(() => {
+
+        // Expect Home Component to be visible
+        expect(element(by.tagName('home')).isDisplayed()).toBe(true);
+
+        // Expect About component to be not be present
+        expect(element(by.tagName('about')).isPresent()).toBe(false);
+      })
+  });
+
+});

--- a/client/app/components/home/home.e2e.js
+++ b/client/app/components/home/home.e2e.js
@@ -1,0 +1,34 @@
+describe('Home Route', () => {
+
+	// Before each test
+	beforeEach(() => {
+
+		// Navigate to home component
+    browser.get('http://localhost:3000');
+  });
+
+
+  // Home component should be visible
+  it('should be visible', () => {
+
+		// Expect home component to be visible
+  	expect(element(by.tagName('home')).isDisplayed()).toBe(true);
+  });
+
+  // Link to About navigates to About Component
+  it('should navigate to About if About link clicked', () => {
+
+    // Click navigation to About route
+    element(by.css('[ui-sref="about"]'))
+      .click()
+      .then(() => {
+
+        // Expect About Component to be visible
+        expect(element(by.tagName('about')).isDisplayed()).toBe(true);
+
+        // Expect Home component to not be present
+        expect(element(by.tagName('home')).isPresent()).toBe(false);
+      })
+  });
+
+});

--- a/generator/component/temp.e2e.js
+++ b/generator/component/temp.e2e.js
@@ -1,0 +1,16 @@
+describe('<%= upCaseName %> Route', () => {
+
+	// Before each test
+	beforeEach(() => {
+
+		// Navigate to <%= name %> component
+    browser.get('http://localhost:3000/<%= name %>');
+  });
+
+  // <%= upCaseName %> component should be visible
+  it('should be visible', () => {
+
+    // Expect <%= upCaseName %> component to be visible
+    expect(element(by.tagName('<%= name %>')).isDisplayed()).toBe(true);
+  });
+});

--- a/generator/component/temp.js
+++ b/generator/component/temp.js
@@ -6,6 +6,15 @@ let <%= name %>Module = angular.module('<%= name %>', [
   uiRouter
 ])
 
+.config(($stateProvider) => {
+  "ngInject";
+  $stateProvider
+    .state('<%= name %>', {
+      url: '/<%= name %>',
+      template: '<<%= name %>></<%= name %>>'
+    });
+})
+
 .component('<%= name %>', <%= name %>Component);
 
 export default <%= name %>Module;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mocha": "^2.3.0",
     "ng-annotate-loader": "0.0.10",
     "node-libs-browser": "^0.5.0",
+    "protractor": "3.1.1",
     "raw-loader": "^0.5.1",
     "run-sequence": "^1.1.0",
     "style-loader": "^0.12.2",
@@ -44,6 +45,10 @@
     "yargs": "^3.9.0"
   },
   "scripts": {
+    "preupdate-webdriver": "npm install",
+    "update-webdriver": "webdriver-manager update",
+    "pree2e": "npm run update-webdriver",
+    "e2e": "protractor protractor.conf.js",
     "test": "karma start"
   },
   "keywords": [

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -1,0 +1,30 @@
+const webpackConfig = require('./webpack.config');
+
+exports.config = {
+	framework: "jasmine",
+	baseUrl: `http://localhost:3000`,
+	seleniumAddress: 'http://localhost:4444/wd/hub',
+	specs: [
+		'client/**/**.e2e.js',
+    'client/**/*.e2e.js'
+	],
+	jasmineNodeOpts: {
+    showTiming: true,
+    showColors: true,
+    isVerbose: true,
+    includeStackTrace: true,
+    defaultTimeoutInterval: 400000
+  },
+  directConnect: true,
+  capabilities: {
+    'browserName': 'chrome',
+    'chromeOptions': {
+      'args': ['show-fps-counter=true']
+    }
+  },
+	allScriptsTimeout: 30000,
+	onPrepare: function () {
+    require("babel-core/register")({ retainLines: true });
+    browser.ignoreSynchronization = true;
+  }
+}


### PR DESCRIPTION
#### To run end to end tests: 
1. Start up the webpack dev server with either gulp serve or gulp watch.
2. Run "npm run e2e" to get automated tests. By just running "protractor" in the root directory, you will see test logs with greater verbosity.


#### E2E Test Generator
I've added a component e2e test file generator, and updated the component module generator with a default route of the component name. In order for the component to be tested, two tasks must still be accomplished.

1. New component must be added to the components.js file.
2. There must be a link to the route somewhere in the app for ui-router to recognize it.

