### PR TITLE
Added missing ES6 support for latest version of gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,17 +90,17 @@ To run tests, type `npm test` or `karma start` in the terminal. Read more about 
 Tools needed to run this app:
 * `node` and `npm`
 Once you have these, install the following as globals:  
-`npm install -g gulp karma karma-cli webpack`
+`npm install -g gulp gulp-cli karma karma-cli webpack`
 
 ## Installing
 * `fork` this repo
 * `clone` your fork
-* `npm install -g gulp karma karma-cli webpack` install global cli dependencies
+* `npm install -g gulp gulp-cli karma karma-cli webpack` install global cli dependencies
 * `npm install` to install dependencies
 
 ## Running the App
 NG6 uses Gulp to build and launch the development environment. After you have installed all dependencies, you may run the app. Running `gulp` will bundle the app with `webpack`, launch a development server, and watch all files. The port will be displayed in the terminal.
- 
+
 ### Gulp Tasks
 Here's a list of available tasks:
 * `webpack`
@@ -113,7 +113,7 @@ Here's a list of available tasks:
 	* runs `serve`.
 * `component`
   * scaffolds a new Angular component. [Read below](#generating-components) for usage details.
-  
+
 ### Testing
 To run the tests, run `npm test` or `karma start`.
 
@@ -161,7 +161,7 @@ Because the argument to `--name` applies to the folder name **and** the actual c
 
 ___
 
-enjoy — **AngularClass** 
+enjoy — **AngularClass**
 
 <br><br>
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
     "type": "git",
     "url": "https://github.com/angularclass/NG6-starter.git"
   },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
+  },
   "author": "AngularClass",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
With latest version of gulp, we get following error when we build the application

```
/Volumes/UUI/Jedi/gulpfile.babel.js:3
import gulp from 'gulp';
^^^^^^
SyntaxError: Unexpected token import
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:511:25)
    at loader (/Volumes/UUI/Jedi/node_modules/babel-register/lib/node.js:158:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Volumes/UUI/Jedi/node_modules/babel-register/lib/node.js:168:7)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at Liftoff.handleArguments (/usr/local/lib/node_modules/gulp/bin/gulp.js:116:3)
```

Latest version of gulp doesn't automatically transpile gulpfile which is written in ES6.
We need additional dependecy `gulp-cli` for latest version of gulp.

Additionally, we also need to set babel preset config in either `.babelrc` or in our `package.json`.
Added this in package.json as well.

Changed files 
- README.md
- package.json