### PR TITLE
Typo in devtool for webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
-  devtool: 'sourcemap',
+  devtool: 'source-map',
   entry: {},
   module: {
     loaders: [


### PR DESCRIPTION
Found this typo in the name for the devtool.  Was trying to figure out why I wasn't getting the nicely formatted files in the browser and this was the culprit.