### PR TITLE
Transition from controllerAs: vm to $ctrl

### DIFF
--- a/client/app/common/hero/hero.component.js
+++ b/client/app/common/hero/hero.component.js
@@ -6,8 +6,7 @@ let heroComponent = {
   restrict: 'E',
   bindings: {},
   template,
-  controller,
-  controllerAs: 'vm'
+  controller
 };
 
 export default heroComponent;

--- a/client/app/common/hero/hero.html
+++ b/client/app/common/hero/hero.html
@@ -1,4 +1,4 @@
 <section class="hero">
   <h1>This is the NG6 starter</h1>
-  <h3>You can find me inside {{ vm.name }}.html</h3>
+  <h3>You can find me inside {{ $ctrl.name }}.html</h3>
 </section>

--- a/client/app/common/hero/hero.spec.js
+++ b/client/app/common/hero/hero.spec.js
@@ -30,7 +30,7 @@ describe('Hero', () => {
     // template specs
     // tip: use regex to ensure correct bindings are used e.g., {{  }}
     it('has name in template [REMOVE]', () => {
-      expect(HeroTemplate).to.match(/{{\s?vm\.name\s?}}/g);
+      expect(HeroTemplate).to.match(/{{\s?\$ctrl\.name\s?}}/g);
     });
   });
 
@@ -40,10 +40,6 @@ describe('Hero', () => {
 
       it('includes the intended template',() => {
         expect(component.template).to.equal(HeroTemplate);
-      });
-
-      it('uses `controllerAs` syntax', () => {
-        expect(component).to.have.property('controllerAs');
       });
 
       it('invokes the right controller', () => {

--- a/client/app/common/navbar/navbar.component.js
+++ b/client/app/common/navbar/navbar.component.js
@@ -6,8 +6,7 @@ let navbarComponent = {
   restrict: 'E',
   bindings: {},
   template,
-  controller,
-  controllerAs: 'vm'
+  controller
 };
 
 export default navbarComponent;

--- a/client/app/common/navbar/navbar.html
+++ b/client/app/common/navbar/navbar.html
@@ -1,6 +1,6 @@
 <nav class="navbar">
   <div class="logo">
-    <h1><a ui-sref="home">{{ vm.name }}</a></h1>
+    <h1><a ui-sref="home">{{ $ctrl.name }}</a></h1>
   </div>
   <div class="nav-links">
     <span><a ui-sref="about">about</a></span>

--- a/client/app/common/navbar/navbar.spec.js
+++ b/client/app/common/navbar/navbar.spec.js
@@ -30,7 +30,7 @@ describe('Navbar', () => {
     // template specs
     // tip: use regex to ensure correct bindings are used e.g., {{  }}
     it('has name in template [REMOVE]', () => {
-      expect(NavbarTemplate).to.match(/{{\s?vm\.name\s?}}/g);
+      expect(NavbarTemplate).to.match(/{{\s?\$ctrl\.name\s?}}/g);
     });
   });
 
@@ -40,10 +40,6 @@ describe('Navbar', () => {
 
       it('includes the intended template',() => {
         expect(component.template).to.equal(NavbarTemplate);
-      });
-
-      it('uses `controllerAs` syntax', () => {
-        expect(component).to.have.property('controllerAs');
       });
 
       it('invokes the right controller', () => {

--- a/client/app/components/about/about.component.js
+++ b/client/app/components/about/about.component.js
@@ -6,8 +6,7 @@ let aboutComponent = {
   restrict: 'E',
   bindings: {},
   template,
-  controller,
-  controllerAs: 'vm'
+  controller
 };
 
 export default aboutComponent;

--- a/client/app/components/about/about.html
+++ b/client/app/components/about/about.html
@@ -1,5 +1,5 @@
 <navbar></navbar>
-<h1>{{ vm.name }}</h1>
+<h1>{{ $ctrl.name }}</h1>
 <section>
   About us.
 </section>

--- a/client/app/components/about/about.spec.js
+++ b/client/app/components/about/about.spec.js
@@ -30,7 +30,7 @@ describe('About', () => {
     // template specs
     // tip: use regex to ensure correct bindings are used e.g., {{  }}
     it('has name in template [REMOVE]', () => {
-      expect(AboutTemplate).to.match(/{{\s?vm\.name\s?}}/g);
+      expect(AboutTemplate).to.match(/{{\s?\$ctrl\.name\s?}}/g);
     });
   });
 
@@ -40,10 +40,6 @@ describe('About', () => {
 
       it('includes the intended template',() => {
         expect(component.template).to.equal(AboutTemplate);
-      });
-
-      it('uses `controllerAs` syntax', () => {
-        expect(component).to.have.property('controllerAs');
       });
 
       it('invokes the right controller', () => {

--- a/client/app/components/home/home.component.js
+++ b/client/app/components/home/home.component.js
@@ -6,8 +6,7 @@ let homeComponent = {
   restrict: 'E',
   bindings: {},
   template,
-  controller,
-  controllerAs: 'vm'
+  controller
 };
 
 export default homeComponent;

--- a/client/app/components/home/home.html
+++ b/client/app/components/home/home.html
@@ -4,6 +4,6 @@
 </header>
 <main>
   <div>
-    <h1>Found in {{ vm.name }}.html</h1>
+    <h1>Found in {{ $ctrl.name }}.html</h1>
   </div>
 </main>

--- a/client/app/components/home/home.spec.js
+++ b/client/app/components/home/home.spec.js
@@ -30,7 +30,7 @@ describe('Home', () => {
     // template specs
     // tip: use regex to ensure correct bindings are used e.g., {{  }}
     it('has name in template [REMOVE]', () => {
-      expect(HomeTemplate).to.match(/{{\s?vm\.name\s?}}/g);
+      expect(HomeTemplate).to.match(/{{\s?\$ctrl\.name\s?}}/g);
     });
   });
 
@@ -40,10 +40,6 @@ describe('Home', () => {
 
       it('includes the intended template',() => {
         expect(component.template).to.equal(HomeTemplate);
-      });
-
-      it('uses `controllerAs` syntax', () => {
-        expect(component).to.have.property('controllerAs');
       });
 
       it('invokes the right controller', () => {

--- a/generator/component/temp.component.js
+++ b/generator/component/temp.component.js
@@ -6,8 +6,7 @@ let <%= name %>Component = {
   restrict: 'E',
   bindings: {},
   template,
-  controller,
-  controllerAs: 'vm'
+  controller
 };
 
 export default <%= name %>Component;

--- a/generator/component/temp.html
+++ b/generator/component/temp.html
@@ -1,3 +1,3 @@
 <div>
-  <h1>{{ vm.name }}</h1>
+  <h1>{{ $ctrl.name }}</h1>
 </div>

--- a/generator/component/temp.spec.js
+++ b/generator/component/temp.spec.js
@@ -30,7 +30,7 @@ describe('<%= upCaseName %>', () => {
     // template specs
     // tip: use regex to ensure correct bindings are used e.g., {{  }}
     it('has name in template [REMOVE]', () => {
-      expect(<%= upCaseName %>Template).to.match(/{{\s?vm\.name\s?}}/g);
+      expect(<%= upCaseName %>Template).to.match(/{{\s?\$ctrl\.name\s?}}/g);
     });
   });
 
@@ -40,10 +40,6 @@ describe('<%= upCaseName %>', () => {
 
       it('includes the intended template',() => {
         expect(component.template).to.equal(<%= upCaseName %>Template);
-      });
-
-      it('uses `controllerAs` syntax', () => {
-        expect(component).to.have.property('controllerAs');
       });
 
       it('invokes the right controller', () => {


### PR DESCRIPTION
As referenced in the following issues:

- https://github.com/angular/angular.js/commit/d91cf167960d47ce38fec0d33cab6119268623f0
- https://github.com/angular/angular.js/issues/13664
- https://github.com/angular/angular.js/pull/13710

`$ctrl` is now the default alias for `controllerAs` syntax. This pull request converts all references in both generator files and currently existing components to utilize `$ctrl` instead of `vm`.

I think that this makes more sense from a project boilerplate standpoint. It's also an approach that @toddmotto recommends: https://github.com/toddmotto/angular-styleguide#controllers

> Do not override the default $ctrl alias for the controllerAs syntax, therefore do not use controllerAs anywhere