### PR TITLE
Fixes #62: Convert currently existing components to export module name.

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -7,8 +7,8 @@ import 'normalize.css';
 
 angular.module('app', [
     uiRouter,
-    Common.name,
-    Components.name
+    Common,
+    Components
   ])
   .config(($locationProvider) => {
     "ngInject";

--- a/client/app/common/common.js
+++ b/client/app/common/common.js
@@ -4,9 +4,11 @@ import Hero from './hero/hero';
 import User from './user/user';
 
 let commonModule = angular.module('app.common', [
-  Navbar.name,
-  Hero.name,
-  User.name
-]);
+  Navbar,
+  Hero,
+  User
+])
+  
+.name;
 
 export default commonModule;

--- a/client/app/common/hero/hero.js
+++ b/client/app/common/hero/hero.js
@@ -6,6 +6,8 @@ let heroModule = angular.module('hero', [
   uiRouter
 ])
 
-.component('hero', heroComponent);
+.component('hero', heroComponent)
+  
+.name;
 
 export default heroModule;

--- a/client/app/common/hero/hero.spec.js
+++ b/client/app/common/hero/hero.spec.js
@@ -6,7 +6,7 @@ import HeroTemplate from './hero.html';
 describe('Hero', () => {
   let $rootScope, makeController;
 
-  beforeEach(window.module(HeroModule.name));
+  beforeEach(window.module(HeroModule));
   beforeEach(inject((_$rootScope_) => {
     $rootScope = _$rootScope_;
     makeController = () => {

--- a/client/app/common/navbar/navbar.js
+++ b/client/app/common/navbar/navbar.js
@@ -6,6 +6,8 @@ let navbarModule = angular.module('navbar', [
   uiRouter
 ])
 
-.component('navbar', navbarComponent);
+.component('navbar', navbarComponent)
+  
+.name;
 
 export default navbarModule;

--- a/client/app/common/navbar/navbar.spec.js
+++ b/client/app/common/navbar/navbar.spec.js
@@ -6,7 +6,7 @@ import NavbarTemplate from './navbar.html';
 describe('Navbar', () => {
   let $rootScope, makeController;
 
-  beforeEach(window.module(NavbarModule.name));
+  beforeEach(window.module(NavbarModule));
   beforeEach(inject((_$rootScope_) => {
     $rootScope = _$rootScope_;
     makeController = () => {

--- a/client/app/common/user/user.js
+++ b/client/app/common/user/user.js
@@ -3,6 +3,8 @@ import UserFactory from './user.factory';
 
 let userModule = angular.module('user', [])
 
-.factory('User', UserFactory);
+.factory('User', UserFactory)
+  
+.name;
 
 export default userModule;

--- a/client/app/components/about/about.js
+++ b/client/app/components/about/about.js
@@ -15,6 +15,8 @@ let aboutModule = angular.module('about', [
     });
 })
 
-.component('about', aboutComponent);
+.component('about', aboutComponent)
+  
+.name;
 
 export default aboutModule;

--- a/client/app/components/about/about.spec.js
+++ b/client/app/components/about/about.spec.js
@@ -6,7 +6,7 @@ import AboutTemplate from './about.html';
 describe('About', () => {
   let $rootScope, makeController;
 
-  beforeEach(window.module(AboutModule.name));
+  beforeEach(window.module(AboutModule));
   beforeEach(inject((_$rootScope_) => {
     $rootScope = _$rootScope_;
     makeController = () => {

--- a/client/app/components/components.js
+++ b/client/app/components/components.js
@@ -3,8 +3,10 @@ import Home from './home/home';
 import About from './about/about';
 
 let componentModule = angular.module('app.components', [
-  Home.name,
-  About.name
-]);
+  Home,
+  About
+])
+  
+.name;
 
 export default componentModule;

--- a/client/app/components/home/home.js
+++ b/client/app/components/home/home.js
@@ -18,6 +18,8 @@ let homeModule = angular.module('home', [
     });
 })
 
-.component('home', homeComponent);
+.component('home', homeComponent)
+  
+.name;
 
 export default homeModule;

--- a/client/app/components/home/home.spec.js
+++ b/client/app/components/home/home.spec.js
@@ -6,7 +6,7 @@ import HomeTemplate from './home.html';
 describe('Home', () => {
   let $rootScope, makeController;
 
-  beforeEach(window.module(HomeModule.name));
+  beforeEach(window.module(HomeModule));
   beforeEach(inject((_$rootScope_) => {
     $rootScope = _$rootScope_;
     makeController = () => {

--- a/generator/component/temp.js
+++ b/generator/component/temp.js
@@ -6,6 +6,8 @@ let <%= name %>Module = angular.module('<%= name %>', [
   uiRouter
 ])
 
-.component('<%= name %>', <%= name %>Component);
+.component('<%= name %>', <%= name %>Component)
+
+.name;
 
 export default <%= name %>Module;

--- a/generator/component/temp.spec.js
+++ b/generator/component/temp.spec.js
@@ -6,7 +6,7 @@ import <%= upCaseName %>Template from './<%= name %>.html';
 describe('<%= upCaseName %>', () => {
   let $rootScope, makeController;
 
-  beforeEach(window.module(<%= upCaseName %>Module.name));
+  beforeEach(window.module(<%= upCaseName %>Module));
   beforeEach(inject((_$rootScope_) => {
     $rootScope = _$rootScope_;
     makeController = () => {


### PR DESCRIPTION
This pull request fixes #62: Convert currently existing components to export module name. Refactor associated tests to strictly import the module instead of accessing module name. Change templates accordingly.

@toddmotto recommends this in https://github.com/toddmotto/angular-styleguide#low-level-modules.