### PR TITLE
Improved name param processing for gulp task `component` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Following a consistent directory structure between components offers us the cert
 You may, of course, create these files manually, every time a new module is needed, but that gets quickly tedious.
 To generate a component, run `npm run component -- --name componentName`.
 
-The parameter following the `--name` flag is the name of the component to be created. Ensure that it is unique or it will overwrite the preexisting identically-named component.
+The parameter following the `--name` flag is the name of the component to be created. Ensure that it is unique or it will overwrite the preexisting identically-named component. This name can use the format `my-name` or `my_name` and will generate the Class MyName.
 
 The component will be created, by default, inside `client/app/components`. To change this, apply the `--parent` flag, followed by a path relative to `client/app/components/`.
 

--- a/generator/component/temp.component.js
+++ b/generator/component/temp.component.js
@@ -2,11 +2,11 @@ import template from './<%= name %>.html';
 import controller from './<%= name %>.controller';
 import './<%= name %>.scss';
 
-let <%= name %>Component = {
+let <%= camelCaseName %>Component = {
   restrict: 'E',
   bindings: {},
   template,
   controller
 };
 
-export default <%= name %>Component;
+export default <%= camelCaseName %>Component;

--- a/generator/component/temp.controller.js
+++ b/generator/component/temp.controller.js
@@ -1,6 +1,6 @@
 class <%= upCaseName %>Controller {
   constructor() {
-    this.name = '<%= name %>';
+    this.name = '<%= camelCaseName %>';
   }
 }
 

--- a/generator/component/temp.js
+++ b/generator/component/temp.js
@@ -1,13 +1,13 @@
 import angular from 'angular';
 import uiRouter from 'angular-ui-router';
-import <%= name %>Component from './<%= name %>.component';
+import <%= camelCaseName %>Component from './<%= name %>.component';
 
-let <%= name %>Module = angular.module('<%= name %>', [
+let <%= camelCaseName %>Module = angular.module('<%= camelCaseName %>', [
   uiRouter
 ])
 
-.component('<%= name %>', <%= name %>Component)
+.component('<%= camelCaseName %>', <%= camelCaseName %>Component)
 
 .name;
 
-export default <%= name %>Module;
+export default <%= camelCaseName %>Module;

--- a/generator/component/temp.scss
+++ b/generator/component/temp.scss
@@ -1,3 +1,3 @@
-.<%= name %> {
+<%= name %> {
   color: red;
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -99,7 +99,14 @@ gulp.task('watch', ['serve']);
 
 gulp.task('component', () => {
   const cap = (val) => {
-    return val.charAt(0).toUpperCase() + val.slice(1);
+    let partials = val.split(/[-,\/_]/);
+    return partials.map(function(str) {
+      return str.charAt(0).toUpperCase() + str.slice(1)
+    }).join('');
+  };
+  const camel = (val) => {
+    var str = cap(val);
+    return str.charAt(0).toLowerCase() + str.slice(1);
   };
   const name = yargs.argv.name;
   const parentPath = yargs.argv.parent || '';
@@ -108,7 +115,8 @@ gulp.task('component', () => {
   return gulp.src(paths.blankTemplates)
     .pipe(template({
       name: name,
-      upCaseName: cap(name)
+      upCaseName: cap(name),
+      camelCaseName: camel(name)
     }))
     .pipe(rename((path) => {
       path.basename = path.basename.replace('temp', name);
@@ -117,7 +125,7 @@ gulp.task('component', () => {
 });
 
 gulp.task('clean', (cb) => {
-  del([paths.dest]).then(function (paths) {
+  del([paths.dest]).then(function(paths) {
     gutil.log("[clean]", paths);
     cb();
   })


### PR DESCRIPTION
This pull request contains updates for the `cap` function in the `gulp` component task.
Now we can create components with names containing `-` and `_`. 

_Example_:
Running: `npm run component -- --name my-component` 
Will generate:
```
/client/app/components/my-component
/client/app/components/my-component/my-component.component.js
/client/app/components/my-component/my-component.controller.js
/client/app/components/my-component/my-component.html
/client/app/components/my-component/my-component.js
/client/app/components/my-component/my-component.scss
/client/app/components/my-component/my-component.spec.js
```
And the controller name will be:
```
class MyComponentController {
  constructor() {
    this.name = 'myComponent';
  }
}

export default MyComponentController;
```

**Changelog:**
- Updated cap function to manage names with "-" and "_".
- Updated temp files to use camelCase instead of upCase.
- Updated CSS selector to match component instead of class.
- Updated Readme