### PR TITLE
fix: trailling styleguide mistakes

### DIFF
--- a/generator/component/temp.spec.js
+++ b/generator/component/temp.spec.js
@@ -1,4 +1,4 @@
-import <%= upCaseName %>Module from './<%= name %>'
+import <%= upCaseName %>Module from './<%= name %>';
 import <%= upCaseName %>Controller from './<%= name %>.controller';
 import <%= upCaseName %>Component from './<%= name %>.component';
 import <%= upCaseName %>Template from './<%= name %>.html';
@@ -35,15 +35,15 @@ describe('<%= upCaseName %>', () => {
   });
 
   describe('Component', () => {
-      // component/directive specs
-      let component = <%= upCaseName %>Component;
+    // component/directive specs
+    let component = <%= upCaseName %>Component;
 
-      it('includes the intended template',() => {
-        expect(component.template).to.equal(<%= upCaseName %>Template);
-      });
+    it('includes the intended template', () => {
+      expect(component.template).to.equal(<%= upCaseName %>Template);
+    });
 
-      it('invokes the right controller', () => {
-        expect(component.controller).to.equal(<%= upCaseName %>Controller);
-      });
+    it('invokes the right controller', () => {
+      expect(component.controller).to.equal(<%= upCaseName %>Controller);
+    });
   });
 });


### PR DESCRIPTION
Hey guys!

I made a little correction on the `temp.spec.js`.

I use your project as a boilerplate and the component scaffolding quite often. Then I've set up eslint on webpack and a CI that runs `eslint .` at the root of the project.

Thing is... the `*.spec.js` files were getting the same style error: `Missing semicollon` and `Space after comma`.

All these components were generated by the scaffolding. So I just fixed this little detail left behind.

Cheers.